### PR TITLE
Amended logical operators in RenderPaymentSheet.php

### DIFF
--- a/src/Affiliation/Controller/Plugin/RenderPaymentSheet.php
+++ b/src/Affiliation/Controller/Plugin/RenderPaymentSheet.php
@@ -463,8 +463,8 @@ class RenderPaymentSheet extends AbstractPlugin
         //Old Invoices
         $upcomingInvoices = [];
         foreach ($affiliation->getInvoice() as $affiliationInvoice) {
-            if ($affiliationInvoice->getYear() > $year or $affiliationInvoice->getYear() === $year
-                and $affiliationInvoice->getPeriod() > $period
+            if ($affiliationInvoice->getYear() > $year || $affiliationInvoice->getYear() === $year
+                && $affiliationInvoice->getPeriod() > $period
             ) {
                 if (!is_null($affiliationInvoice->getInvoice()->getDateSent())) {
                     $upcomingInvoices[] = $affiliationInvoice;

--- a/src/Affiliation/Controller/Plugin/RenderPaymentSheet.php
+++ b/src/Affiliation/Controller/Plugin/RenderPaymentSheet.php
@@ -347,10 +347,10 @@ class RenderPaymentSheet extends AbstractPlugin
         $previousInvoices = [];
         foreach ($affiliation->getInvoice() as $affiliationInvoice) {
             if (!is_null($affiliationInvoice->getInvoice()->getDayBookNumber())
-                && ($affiliationInvoice->getYear() < $year
-                    || ($affiliationInvoice->getYear() === $year
-                        && $affiliationInvoice->getPeriod() < $period))
-            ) {
+                && ($affiliationInvoice->getYear() < $year)
+                    || ($affiliationInvoice->getYear() === $year)
+                        && ($affiliationInvoice->getPeriod() < $period))
+            {
                 $previousInvoices[] = $affiliationInvoice;
             }
         }


### PR DESCRIPTION
Hello. 

I amended the logical operators in src/Affiliation/Controller/Plugin/RenderPaymentSheet.php. The reason for this is that The and operator does not have the same precedence as && and the or operator does not have the same precedence as ||. These could have led to unexpected behaviour and carries a major bug risk.

Thank you.
